### PR TITLE
Update classpath arguments to use `:` instead of `;`

### DIFF
--- a/dist/JRomManagerCLI.sh
+++ b/dist/JRomManagerCLI.sh
@@ -12,4 +12,4 @@ if [ $? -eq 0 ]; then
 		if [ $? -eq 0 ]; then OPT=-xmx2g; fi
 	fi
 fi
-java $OPT -cp "JRomManager.jar;lib/*"  jrm.cli.JRomManagerCLI
+java $OPT -cp "JRomManager.jar:lib/*"  jrm.cli.JRomManagerCLI

--- a/dist/JRomManagerFullServer.sh
+++ b/dist/JRomManagerFullServer.sh
@@ -12,4 +12,4 @@ if [ $? -eq 0 ]; then
 		if [ $? -eq 0 ]; then OPT=-xmx2g; fi
 	fi
 fi
-java $OPT -cp "JRomManager.jar;lib/*"  jrm.fullserver.FullServer
+java $OPT -cp "JRomManager.jar:lib/*"  jrm.fullserver.FullServer

--- a/dist/JRomManagerServer.sh
+++ b/dist/JRomManagerServer.sh
@@ -12,4 +12,4 @@ if [ $? -eq 0 ]; then
 		if [ $? -eq 0 ]; then OPT=-xmx2g; fi
 	fi
 fi
-java $OPT -cp "JRomManager.jar;lib/*"  jrm.server.Server
+java $OPT -cp "JRomManager.jar:lib/*"  jrm.server.Server


### PR DESCRIPTION
Unix systems need to use colons instead of semi-colons for class path separators