### PR TITLE
Potential fix for code scanning alert no. 8: Server-side request forgery

### DIFF
--- a/jrmserver/src/main/java/jrm/server/shared/handlers/ImageServlet.java
+++ b/jrmserver/src/main/java/jrm/server/shared/handlers/ImageServlet.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLConnection;
+import java.net.URLDecoder;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.time.ZoneId;
@@ -51,16 +52,21 @@ public class ImageServlet extends HttpServlet {
         if (requestUri == null || requestUri.length() <= 8) {
             throw new URISyntaxException(String.valueOf(requestUri), "Invalid request URI");
         }
-        String resourcePath = requestUri.substring(8);
-        if (resourcePath.isEmpty() || resourcePath.contains("..") || resourcePath.contains("\\") || resourcePath.contains(":")
-                || resourcePath.contains("\0") || resourcePath.startsWith("//")) {
+
+        String resourcePath = URLDecoder.decode(requestUri.substring(8), java.nio.charset.StandardCharsets.UTF_8);
+        if (resourcePath.isEmpty() || !resourcePath.startsWith("/") || resourcePath.contains("\\") || resourcePath.contains("\0")) {
             throw new URISyntaxException(resourcePath, "Disallowed resource path");
         }
 
-        URI baseUri = getURI();
-        URI resolved = URI.create(baseUri.toString() + resourcePath).normalize();
-        String basePrefix = baseUri.toString();
-        if (!resolved.toString().startsWith(basePrefix)) {
+        URI baseUri = getURI().normalize();
+        URI resolved = baseUri.resolve("." + resourcePath).normalize();
+
+        String basePath = baseUri.getPath() == null ? "" : baseUri.getPath();
+        String resolvedPath = resolved.getPath() == null ? "" : resolved.getPath();
+        if (!resolvedPath.startsWith(basePath)
+                || !baseUri.getScheme().equalsIgnoreCase(resolved.getScheme())
+                || (baseUri.getHost() != null && !baseUri.getHost().equalsIgnoreCase(resolved.getHost()))
+                || baseUri.getPort() != resolved.getPort()) {
             throw new URISyntaxException(resourcePath, "Resolved path escapes base URI");
         }
         return resolved;
@@ -71,6 +77,10 @@ public class ImageServlet extends HttpServlet {
         try {
             val uri = resolveRequestedResourceUri(req.getRequestURI());
             val url = uri.toURL();
+            String scheme = uri.getScheme();
+            if (scheme == null || !(scheme.equalsIgnoreCase("jrt") || scheme.equalsIgnoreCase("jar") || scheme.equalsIgnoreCase("file"))) {
+                throw new IOException("Unsupported URI scheme");
+            }
             val urlconn = url.openConnection();
             urlconn.setDoInput(true);
             if (urlconn.getContentLength() == 0) {


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/8](https://github.com/optyfr/JRomManager/security/code-scanning/8)

Use strict, canonicalized path handling and explicit scheme allowlisting before opening a connection.

Best fix in this file:
1. In `resolveRequestedResourceUri`, stop using string concatenation to build the URI.
2. Canonicalize and validate the servlet path segment (`/img/...`) by decoding, requiring it to start with `/`, and forbidding traversal.
3. Resolve via `baseUri.resolve("." + normalizedPath)` and then verify with URI-object checks (scheme/host/port/path), not `toString().startsWith(...)`.
4. In `doGet`, enforce scheme allowlist (`jrt`, `jar`, `file`) before `openConnection()`.

Edits are only in `jrmserver/src/main/java/jrm/server/shared/handlers/ImageServlet.java`:
- Add import: `java.net.URLDecoder`.
- Replace `resolveRequestedResourceUri` implementation.
- Add scheme check in `doGet` between `uri.toURL()` and `openConnection()`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
