### PR TITLE
Potential fix for code scanning alert no. 24: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/jrmcore/src/test/java/jrm/profile/scan/ScanFixSoftwareListTest.java
+++ b/jrmcore/src/test/java/jrm/profile/scan/ScanFixSoftwareListTest.java
@@ -123,11 +123,15 @@ class ScanFixSoftwareListTest {
      * @throws IOException if extraction fails
      */
     private File extractJrmZip(Path zipPath, Path targetDir) throws IOException {
+        final Path normalizedTargetDir = targetDir.toAbsolutePath().normalize();
         try (ZipFile zipFile = new ZipFile(zipPath.toFile())) {
             Enumeration<? extends ZipEntry> entries = zipFile.entries();
             while (entries.hasMoreElements()) {
                 ZipEntry entry = entries.nextElement();
-                Path targetPath = targetDir.resolve(entry.getName());
+                Path targetPath = normalizedTargetDir.resolve(entry.getName()).normalize();
+                if (!targetPath.startsWith(normalizedTargetDir)) {
+                    throw new IOException("Bad zip entry: " + entry.getName());
+                }
 
                 if (entry.isDirectory()) {
                     Files.createDirectories(targetPath);


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/24](https://github.com/optyfr/JRomManager/security/code-scanning/24)

To fix Zip Slip safely, resolve each archive entry path against the destination, normalize it, and verify it still starts with the normalized destination directory. Reject entries that escape the target directory.

Best single fix in `jrmcore/src/test/java/jrm/profile/scan/ScanFixSoftwareListTest.java` (inside `extractJrmZip`) is:

- Compute `Path normalizedTargetDir = targetDir.toAbsolutePath().normalize();` once.
- For each entry:
  - Build `Path targetPath = normalizedTargetDir.resolve(entry.getName()).normalize();`
  - Validate: `if (!targetPath.startsWith(normalizedTargetDir)) throw new IOException(...)`
- Use `targetPath` only after validation for both directory creation and file copy.

This addresses all 3 alert variants (line 133/135/137 sinks) with one guard and preserves existing behavior for valid ZIPs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
