### PR TITLE
Potential fix for code scanning alert no. 17: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/jrmserver/src/main/java/jrm/server/shared/datasources/RemoteFileChooserXMLResponse.java
+++ b/jrmserver/src/main/java/jrm/server/shared/datasources/RemoteFileChooserXMLResponse.java
@@ -10,6 +10,7 @@ import java.nio.file.Path;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
+import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.BasicFileAttributeView;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.Comparator;
@@ -606,19 +607,24 @@ public class RemoteFileChooserXMLResponse extends XMLResponse {
      */
     private void unzip(Path zipfile, Path outputPath) {
         try (var zf = new ZipFile(zipfile.toFile())) {
+            Path normalizedOutputPath = outputPath.toAbsolutePath().normalize();
 
             Enumeration<? extends ZipEntry> zipEntries = zf.entries();
             new EnumerationToIterator<>(zipEntries).forEachRemaining(entry -> {
                 try {
+                    Path resolvedPath = normalizedOutputPath.resolve(entry.getName()).normalize();
+                    if (!resolvedPath.startsWith(normalizedOutputPath)) {
+                        Log.err("Skipping unsafe zip entry outside target dir: " + entry.getName());
+                        return;
+                    }
+
                     if (entry.isDirectory()) {
-                        var dirToCreate = outputPath.resolve(entry.getName());
-                        if (!Files.exists(dirToCreate))
-                            Files.createDirectories(dirToCreate);
+                        if (!Files.exists(resolvedPath))
+                            Files.createDirectories(resolvedPath);
                     } else {
-                        var fileToCreate = outputPath.resolve(entry.getName());
-                        if (!Files.exists(fileToCreate.getParent()))
-                            Files.createDirectories(fileToCreate.getParent());
-                        Files.copy(zf.getInputStream(entry), fileToCreate);
+                        if (!Files.exists(resolvedPath.getParent()))
+                            Files.createDirectories(resolvedPath.getParent());
+                        Files.copy(zf.getInputStream(entry), resolvedPath, StandardCopyOption.REPLACE_EXISTING);
                     }
                 } catch (IOException ei) {
                     Log.err(ei.getMessage(), ei);


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/17](https://github.com/optyfr/JRomManager/security/code-scanning/17)

Use a safe extraction pattern: for each `ZipEntry`, resolve its name against a normalized destination root, normalize the resolved path, and verify it still starts with that root using `Path.startsWith`. Reject entries that fail this check.

Best single fix in `jrmserver/src/main/java/jrm/server/shared/datasources/RemoteFileChooserXMLResponse.java`:
- In `unzip(...)`, compute `Path normalizedOutputPath = outputPath.toAbsolutePath().normalize();` once.
- For each entry, compute `resolvedPath = normalizedOutputPath.resolve(entry.getName()).normalize();`
- Check `if (!resolvedPath.startsWith(normalizedOutputPath))` and skip/log (or throw).  
- Use `resolvedPath` (not the raw `resolve(entry.getName())`) for both directory creation and file copy.
- Also use `StandardCopyOption.REPLACE_EXISTING` for deterministic overwrite behavior matching existing intent to copy extracted files without failing when files already exist (optional but safe and common in unzip flows).

This addresses both variants at line 620 and 621 because both parent directory creation and file write now operate only on validated paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
