### PR TITLE
Potential fix for code scanning alert no. 16: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/jrmserver/src/main/java/jrm/server/shared/datasources/RemoteFileChooserXMLResponse.java
+++ b/jrmserver/src/main/java/jrm/server/shared/datasources/RemoteFileChooserXMLResponse.java
@@ -606,19 +606,22 @@ public class RemoteFileChooserXMLResponse extends XMLResponse {
      */
     private void unzip(Path zipfile, Path outputPath) {
         try (var zf = new ZipFile(zipfile.toFile())) {
+            final Path normalizedOutputPath = outputPath.toAbsolutePath().normalize();
 
             Enumeration<? extends ZipEntry> zipEntries = zf.entries();
             new EnumerationToIterator<>(zipEntries).forEachRemaining(entry -> {
                 try {
+                    var resolvedPath = normalizedOutputPath.resolve(entry.getName()).normalize();
+                    if (!resolvedPath.startsWith(normalizedOutputPath))
+                        throw new IOException("Bad zip entry: " + entry.getName());
+
                     if (entry.isDirectory()) {
-                        var dirToCreate = outputPath.resolve(entry.getName());
-                        if (!Files.exists(dirToCreate))
-                            Files.createDirectories(dirToCreate);
+                        if (!Files.exists(resolvedPath))
+                            Files.createDirectories(resolvedPath);
                     } else {
-                        var fileToCreate = outputPath.resolve(entry.getName());
-                        if (!Files.exists(fileToCreate.getParent()))
-                            Files.createDirectories(fileToCreate.getParent());
-                        Files.copy(zf.getInputStream(entry), fileToCreate);
+                        if (!Files.exists(resolvedPath.getParent()))
+                            Files.createDirectories(resolvedPath.getParent());
+                        Files.copy(zf.getInputStream(entry), resolvedPath);
                     }
                 } catch (IOException ei) {
                     Log.err(ei.getMessage(), ei);


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/16](https://github.com/optyfr/JRomManager/security/code-scanning/16)

To fix Zip Slip safely, each ZIP entry path must be resolved against `outputPath`, normalized, and verified to remain within `outputPath` before creating directories or writing files.

Best fix in this file:
- In `unzip(...)`, compute a normalized base directory once: `outputPath.toAbsolutePath().normalize()`.
- For each entry, compute `resolvedPath = baseOutputPath.resolve(entry.getName()).normalize()`.
- Reject entries where `resolvedPath` does not start with `baseOutputPath`.
- Use `resolvedPath` for directory creation and file copy, instead of direct `resolve(entry.getName())`.

This preserves behavior for valid archives while blocking traversal entries.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
