### PR TITLE
Potential fix for code scanning alert no. 21: Uncontrolled data used in path expression

### DIFF
--- a/jrmcore/src/main/java/jrm/security/PathAbstractor.java
+++ b/jrmcore/src/main/java/jrm/security/PathAbstractor.java
@@ -199,7 +199,7 @@ public class PathAbstractor {
             if (!path.startsWith(basepath))
                 throw new SecurityException(FORGED_PATH);
         } else
-            path = Paths.get(strpath);
+            throw new SecurityException(FORGED_PATH);
         return path;
     }
 


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/21](https://github.com/optyfr/JRomManager/security/code-scanning/21)

The safest fix is to enforce server-side validation in `PathAbstractor.getAbsolutePath(Session, String)` by rejecting any abstract path that does not start with one of the supported placeholders. This preserves existing intended functionality (resolving `%presets`, `%work`, `%shared`) while removing the dangerous fallback that accepted raw filesystem paths.

Best concrete change:
- **File:** `jrmcore/src/main/java/jrm/security/PathAbstractor.java`
- **Region:** `getAbsolutePath(Session session, final String strpath)` method, specifically the final `else` branch.
- Replace `path = Paths.get(strpath);` with throwing `SecurityException(FORGED_PATH)` (or equivalent existing security message), so untrusted non-abstract paths cannot be used.
- No new imports/dependencies required.

This is the minimal, robust fix because it centralizes validation at the path-resolution boundary used by servlet code, preventing unsafe path usage at all sinks (`Files.copy`, `Files.walkFileTree`, etc.).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
