### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches: [ master ]
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/23](https://github.com/optyfr/JRomManager/security/code-scanning/23)

Add an explicit `permissions` block to the workflow so token scope is least-privilege and deterministic.

Best fix here: define workflow-level permissions right under `on:` (before `jobs:`), with at least:
- `contents: read` (required minimal baseline for checkout/repo read)
- `packages: read` (safe/additional read scope commonly needed by build/container tooling; also aligns with your background guidance)

This does not change existing behavior of build/push logic, but it removes dependence on mutable repository/org defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
