### PR TITLE
Potential fix for code scanning alert no. 22: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/sonarqube.yml
+++ b/.github/workflows/sonarqube.yml
@@ -5,6 +5,8 @@ on:
       - '*'
   pull_request:
     types: [opened, synchronize, reopened]
+permissions:
+  contents: read
 jobs:
   build:
     name: Build


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/22](https://github.com/optyfr/JRomManager/security/code-scanning/22)

Add an explicit `permissions` block to `.github/workflows/sonarqube.yml` so the workflow does not rely on repository/org defaults.  
Best fix without changing functionality: define workflow-level permissions right after the `on` trigger and before `jobs`, using the minimum guaranteed needed scope:

- `contents: read` (for checkout/repo read access)

This satisfies the CodeQL requirement and preserves behavior. If later Sonar PR decoration needs extra scopes, those can be added explicitly at job level, but the minimal secure baseline should be introduced now.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
