### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
     - '*'
 
+permissions:
+  contents: write
+
 jobs:
 
   build_linux:


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/6](https://github.com/optyfr/JRomManager/security/code-scanning/6)

Add an explicit `permissions:` block at the workflow root in `.github/workflows/release.yml` so all jobs inherit least-privilege defaults. Since the workflow uploads/updates GitHub Releases via `GITHUB_TOKEN`, it needs `contents: write` (not just read). This is the minimal practical permission for release publishing; no broader scopes are required from the shown steps.

Best single fix without changing behavior:
- Edit `.github/workflows/release.yml`
- Insert `permissions:` directly under `on:` block (before `jobs:`), with:
  - `contents: write`

No imports, methods, or dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
