### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
     - '*'
 
+permissions:
+  contents: write
+
 jobs:
 
   build_linux:


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/5](https://github.com/optyfr/JRomManager/security/code-scanning/5)

Add an explicit `permissions` block in `.github/workflows/release.yml` so token access is documented and least-privilege is enforced.

Best single fix without changing functionality: define workflow-level permissions that satisfy this workflow’s needs, especially release publishing. Since jobs invoke a release action that updates GitHub Releases and upload assets, `contents: write` is required. This also covers checkout reads. Add:

- `permissions:`
  - `contents: write`

at the workflow root, directly under `on:` and before `jobs:`.  
This keeps existing behavior intact while removing reliance on repo/org defaults and satisfying CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
