### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     tags:
     - '*'
 
+permissions:
+  contents: write
+  packages: write
+
 jobs:
 
   build_linux:


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/4](https://github.com/optyfr/JRomManager/security/code-scanning/4)

Add an explicit `permissions:` block to `.github/workflows/release.yml` so token scopes are intentionally defined instead of inherited implicitly.

Best single fix without changing behavior:
- Add workflow-level permissions near the top (after `on:` and before `jobs:` is typical) with:
  - `contents: write` (required for creating/updating releases and uploading release assets via `ncipollo/release-action`).
  - `packages: write` (needed for pushing images to GHCR if used in this workflow; the snippet includes Docker/metadata/push behavior and this is commonly required).
  
This preserves existing functionality while removing the CodeQL finding and documenting required privileges. No imports/dependencies/method changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
