### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
     - '*'
 
+permissions:
+  contents: write
+
 jobs:
 
   build_linux:


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/1](https://github.com/optyfr/JRomManager/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root in `.github/workflows/release.yml` (immediately after `on:` block and before `jobs:`).  
This keeps behavior intact while documenting and constraining token access for all jobs.

Given this workflow:
- checks out code (`contents: read` needed),
- creates/updates GitHub releases via `ncipollo/release-action` (`contents: write` needed),
- pushes Docker images to Docker Hub using separate Docker credentials (no extra GitHub token write scopes required there).

So the best minimal safe fix is:

```yml
permissions:
  contents: write
```

This is preferable to leaving defaults implicit, and safer than over-granting unrelated scopes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
