### PR TITLE
Potential fix for code scanning alert no. 15: Uncontrolled data used in path expression

### DIFF
--- a/jrmserver/src/main/java/jrm/server/shared/handlers/UploadServlet.java
+++ b/jrmserver/src/main/java/jrm/server/shared/handlers/UploadServlet.java
@@ -285,10 +285,21 @@ public class UploadServlet extends HttpServlet {
      */
     String sanitizeHeader(final String header) throws IOException {
         final String decoded = URLDecoder.decode(header, UTF_8);
-        // Remove path traversal attempts and dangerous characters
-        return decoded.replace("..", "")
-                      .replace("\0", "")
+        // Keep decoding and control-character cleanup; structural path safety is validated at use sites.
+        return decoded.replace("\0", "")
                       .replaceAll("[\\p{Cntrl}]", "");
+    }
+
+    /**
+     * Validates that a user-provided filename is a single safe path component.
+     *
+     * @param filename decoded/sanitized filename header value
+     * @throws SecurityException if the filename is invalid
+     */
+    void validateFileNameComponent(final String filename) {
+        if (filename == null || filename.isBlank() || ".".equals(filename) || "..".equals(filename) || filename.contains("..") || filename.contains("/") || filename.contains("\\")) {
+            throw new SecurityException("Invalid filename");
+        }
     }
 
     /**
@@ -320,9 +331,13 @@ public class UploadServlet extends HttpServlet {
                 final var result = new Result();
                 final String filename = sanitizeHeader(req.getHeader("x-file-name"));
                 final String fileparent = sanitizeHeader(req.getHeader("x-file-parent"));
+                validateFileNameComponent(filename);
                 if (pathAbstractor.isWriteable(fileparent)) {
-                    final var dest = pathAbstractor.getAbsolutePath(fileparent);
-                    final var filepath = dest.resolve(filename);
+                    final var dest = pathAbstractor.getAbsolutePath(fileparent).normalize().toAbsolutePath();
+                    final var filepath = dest.resolve(filename).normalize().toAbsolutePath();
+                    if (!filepath.startsWith(dest)) {
+                        throw new SecurityException("Invalid upload path");
+                    }
                     Files.createDirectories(filepath.getParent());
                     doUpload(req, result, filename, filepath);
                     if (result.status != 3) {


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/15](https://github.com/optyfr/JRomManager/security/code-scanning/15)

To fix this safely without changing intended functionality:

1. **Treat `x-file-name` as a single path component**, not a path:
   - Reject empty names.
   - Reject names containing `/`, `\`, or `..`.
2. **Resolve and normalize** the destination path and enforce containment:
   - Compute `destNormalized = dest.normalize().toAbsolutePath()`.
   - Compute `filepath = destNormalized.resolve(filename).normalize().toAbsolutePath()`.
   - Reject if `!filepath.startsWith(destNormalized)`.
3. Keep existing `PathAbstractor.isWriteable(fileparent)` logic for parent directory policy, but add these explicit checks in `UploadServlet#doPut` before directory creation and upload.
4. Update `sanitizeHeader` so it decodes and strips dangerous control/null chars, but does not pretend traversal is removed by string replacement; traversal prevention should be done by strict validation/checks where the path is built.

Edits are only needed in:
- `jrmserver/src/main/java/jrm/server/shared/handlers/UploadServlet.java`
  - Replace `sanitizeHeader(...)` body.
  - Add helper `validateFileNameComponent(...)`.
  - Update `doPut(...)` around lines 321–327 to validate and enforce containment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
