### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled data used in path expression

### DIFF
--- a/jrmserver/src/main/java/jrm/server/shared/handlers/UploadServlet.java
+++ b/jrmserver/src/main/java/jrm/server/shared/handlers/UploadServlet.java
@@ -322,12 +322,23 @@ public class UploadServlet extends HttpServlet {
                 final String fileparent = sanitizeHeader(req.getHeader("x-file-parent"));
                 if (pathAbstractor.isWriteable(fileparent)) {
                     final var dest = pathAbstractor.getAbsolutePath(fileparent);
-                    final var filepath = dest.resolve(filename);
-                    Files.createDirectories(filepath.getParent());
-                    doUpload(req, result, filename, filepath);
-                    if (result.status != 3) {
-                        Log.debug(() -> result.status + " : " + result.extstatus);
-                        Files.delete(filepath);
+                    final var baseDir = dest.normalize().toAbsolutePath();
+                    if (filename.contains("..") || filename.contains("/") || filename.contains("\\")) {
+                        result.status = 8;
+                        result.extstatus = INVALID_PATH;
+                    } else {
+                        final var filepath = baseDir.resolve(filename).normalize().toAbsolutePath();
+                        if (!filepath.startsWith(baseDir)) {
+                            result.status = 8;
+                            result.extstatus = INVALID_PATH;
+                        } else {
+                            Files.createDirectories(filepath.getParent());
+                            doUpload(req, result, filename, filepath);
+                            if (result.status != 3) {
+                                Log.debug(() -> result.status + " : " + result.extstatus);
+                                Files.delete(filepath);
+                            }
+                        }
                     }
                 } else {
                     result.status = 11;


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/14](https://github.com/optyfr/JRomManager/security/code-scanning/14)

The robust fix is to canonicalize and validate resolved paths, not to “clean” strings. Keep existing behavior (still decoding headers and using `PathAbstractor`) but add strict checks that:

1. `filename` is a single path component (no `/`, `\`, or `..`).
2. `dest.resolve(filename)` normalized absolute path remains within `dest` normalized absolute path.

Best concrete change in `jrmserver/src/main/java/jrm/server/shared/handlers/UploadServlet.java`:
- In `doPut`, after obtaining `dest`, compute normalized absolute `baseDir` and `filepath`.
- Reject if `filename` is invalid as a leaf name.
- Reject if `filepath` escapes `baseDir`.
- On rejection, return the same invalid-path style response (`status = 8`, `extstatus = INVALID_PATH`) to preserve existing API style.
- Keep existing write/upload/delete flow unchanged for valid paths.

No new dependency is required; use `java.nio.file.Path` operations already imported.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
