### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled data used in path expression

### DIFF
--- a/jrmserver/src/main/java/jrm/server/shared/handlers/UploadServlet.java
+++ b/jrmserver/src/main/java/jrm/server/shared/handlers/UploadServlet.java
@@ -292,6 +292,18 @@ public class UploadServlet extends HttpServlet {
     }
 
     /**
+     * Validates that a user-provided filename is a single path component.
+     *
+     * @param filename the candidate filename from request headers
+     * @throws SecurityException if the filename is invalid
+     */
+    void validateFilenameComponent(final String filename) {
+        if (filename == null || filename.isBlank() || filename.contains("..") || filename.contains("/") || filename.contains("\\")) {
+            throw new SecurityException("Invalid filename");
+        }
+    }
+
+    /**
      * Handles HTTP PUT requests for actual file upload and disk writing.
      * <p>
      * This method processes PUT requests to the "/upload/" endpoint to perform the actual file transfer. It:
@@ -320,9 +332,13 @@ public class UploadServlet extends HttpServlet {
                 final var result = new Result();
                 final String filename = sanitizeHeader(req.getHeader("x-file-name"));
                 final String fileparent = sanitizeHeader(req.getHeader("x-file-parent"));
+                validateFilenameComponent(filename);
                 if (pathAbstractor.isWriteable(fileparent)) {
-                    final var dest = pathAbstractor.getAbsolutePath(fileparent);
-                    final var filepath = dest.resolve(filename);
+                    final var dest = pathAbstractor.getAbsolutePath(fileparent).normalize().toAbsolutePath();
+                    final var filepath = dest.resolve(filename).normalize().toAbsolutePath();
+                    if (!filepath.startsWith(dest)) {
+                        throw new SecurityException("Invalid upload path");
+                    }
                     Files.createDirectories(filepath.getParent());
                     doUpload(req, result, filename, filepath);
                     if (result.status != 3) {


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/13](https://github.com/optyfr/JRomManager/security/code-scanning/13)

Use defense-in-depth on both user inputs before any filesystem operation:

1. Treat `x-file-name` as a **single filename component** (not a path).
2. Resolve the final path against a trusted base directory and verify normalized containment.

Best single fix in this file:
- Add a helper method to validate `filename` so it rejects separators (`/`, `\`), `".."`, and empty/blank values.
- In `doPut`, after `dest` is obtained from `pathAbstractor`, normalize/absolutize both `dest` and resolved `filepath`, then enforce `filepath.startsWith(dest)`.
- If validation fails, throw `SecurityException` so existing handling returns the existing invalid-path response.
- Use the validated/resolved `filepath` for `createDirectories`, `doUpload`, and cleanup delete.

This keeps behavior intact for valid uploads while preventing traversal/path injection via both filename and parent variants.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
