### PR TITLE
Potential fix for code scanning alert no. 12: Uncontrolled data used in path expression

### DIFF
--- a/jrmserver/src/main/java/jrm/server/shared/handlers/UploadServlet.java
+++ b/jrmserver/src/main/java/jrm/server/shared/handlers/UploadServlet.java
@@ -217,6 +217,7 @@ public class UploadServlet extends HttpServlet {
             result.extstatus = "continue...";
             final String filename = sanitizeHeader(req.getHeader("x-file-name"));
             final String fileparent = sanitizeHeader(req.getHeader("x-file-parent"));
+            validateUploadHeaders(filename, fileparent);
             if (pathAbstractor.isWriteable(fileparent)) {
                 final var filesize = getXFileSize(req);
                 final var dest = pathAbstractor.getAbsolutePath(fileparent);
@@ -283,6 +284,15 @@ public class UploadServlet extends HttpServlet {
      * 
      * @throws IOException if URL decoding fails
      */
+    private void validateUploadHeaders(final String filename, final String fileparent) {
+        if (filename == null || filename.isBlank() || filename.contains("/") || filename.contains("\\") || filename.contains("..")) {
+            throw new InvalidPathException(String.valueOf(filename), "Invalid filename");
+        }
+        if (fileparent == null || fileparent.isBlank() || !fileparent.startsWith("%") || fileparent.contains("\0")) {
+            throw new InvalidPathException(String.valueOf(fileparent), "Invalid file parent");
+        }
+    }
+
     String sanitizeHeader(final String header) throws IOException {
         final String decoded = URLDecoder.decode(header, UTF_8);
         // Remove path traversal attempts and dangerous characters


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/12](https://github.com/optyfr/JRomManager/security/code-scanning/12)

To fix this safely without changing intended functionality, enforce strict validation of upload path components in `UploadServlet.checkRequest` before using them in path resolution or filesystem calls:

1. Treat `x-file-name` as a single filename component (no separators, no `..`).
2. Require `x-file-parent` to be an abstract/sandboxed path (must start with `%`), preventing raw absolute/relative OS paths from user input.
3. Keep existing `PathAbstractor` checks and writable checks, but fail fast on invalid header format.

Best single fix in the provided code is to add a helper method in `UploadServlet` that validates these header values and throws `InvalidPathException` when invalid, then call it in `checkRequest` immediately after sanitization. This integrates with existing exception handling (`InvalidPathException | SecurityException` -> status 8 / `INVALID_PATH`) and avoids broad behavior changes elsewhere.

Edit region:
- `jrmserver/src/main/java/jrm/server/shared/handlers/UploadServlet.java`
  - In `checkRequest(...)`, add validation call after reading `filename` and `fileparent`.
  - Add a new private validator method near `sanitizeHeader(...)`.

No new dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
