### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
     - '*'
 
+permissions:
+  contents: read
+
 jobs:
 
   build_linux:
@@ -130,6 +133,8 @@ jobs:
         labels: ${{ steps.meta.outputs.labels }}
         
   build_windows:
+    permissions:
+      contents: write
     env:
       beta: ${{contains(github.ref, 'beta')}}
     needs: build_linux
@@ -176,6 +181,8 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         
   build_macos_x64:
+    permissions:
+      contents: write
     env:
       beta: ${{contains(github.ref, 'beta')}}
     needs: build_windows
@@ -213,6 +220,8 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         
   build_macos_aarch64:
+    permissions:
+      contents: write
     env:
       beta: ${{contains(github.ref, 'beta')}}
     needs: build_windows


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/6](https://github.com/optyfr/JRomManager/security/code-scanning/6)

Add an explicit `permissions` block in `.github/workflows/release.yml` to enforce least privilege.

Best fix without changing intended behavior:
- Define a workflow-level permission baseline:
  - `contents: read` (minimal safe default for most jobs).
- For jobs that publish/update GitHub Releases using `ncipollo/release-action`, override with job-level:
  - `contents: write` (required to create/update releases and upload release assets).

From the snippet, release publishing is present in:
- `build_windows` (MSI release step),
- `build_macos_x64` (DMG release step),
- `build_macos_aarch64` (DMG release step).

So:
1. Insert root-level `permissions: contents: read` after the `on:` block.
2. Add `permissions: contents: write` under each of those jobs (alongside `env`, `needs`, `runs-on`, etc.).

No imports/dependencies/methods are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
