### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,9 @@ on:
     tags:
     - '*'
 
+permissions:
+  contents: write
+
 jobs:
 
   build_linux:


### PR DESCRIPTION
Potential fix for [https://github.com/optyfr/JRomManager/security/code-scanning/1](https://github.com/optyfr/JRomManager/security/code-scanning/1)

Add an explicit `permissions:` block in `.github/workflows/release.yml` at the workflow root (top-level, after `on:` and before `jobs:`), so all jobs inherit it unless overridden.

Best single fix here (without changing behavior) is:
- Set `contents: write` because release creation/update requires writing to repository contents/releases via `GITHUB_TOKEN`.
- Keep scope minimal by only granting what this workflow needs globally.

Concretely:
- Edit `.github/workflows/release.yml` near lines 8–10 (between trigger and jobs).
- No imports/dependencies/methods are needed (YAML-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
